### PR TITLE
Improve selector to handle NodeList, HTMLCollection, Element or string

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -68,6 +68,12 @@ const enter = (...args) => intent('mouseenter', 'mouseleave', ...args)
 
 const leave = (...args) => intent('mouseleave', 'mouseenter', ...args)
 
+const objectTypeOf = someVariable =>
+  Object.prototype.toString
+    .call(someVariable)
+    .slice(8, -1)
+    .toLowerCase()
+
 export default class HoverIntent {
   constructor(selector, enterCallback, leaveCallback, options) {
     const defaultOptions = {
@@ -75,7 +81,17 @@ export default class HoverIntent {
       leaveWait: 100
     }
 
-    this.selector = document.querySelectorAll(selector)
+    this.selector = selector
+    if (
+      objectTypeOf(selector) !== 'nodelist' &&
+      objectTypeOf(selector) !== 'htmlcollection'
+    ) {
+      this.selector =
+        typeof selector === 'object'
+          ? [selector]
+          : document.querySelectorAll(selector)
+    }
+
     this.options = Object.assign({}, defaultOptions, options)
 
     this.cancelEnter = enter(


### PR DESCRIPTION
Allow 1st argument to be a NodeList, Element or string
Improved type detection to allow :
* NodeList or HTMLCollection: as is
* Element: convert to array
* string (default): use document.querySelectorAll()